### PR TITLE
docs: rulesyncについての説明を追加

### DIFF
--- a/docs/細かい設計方針.md
+++ b/docs/細かい設計方針.md
@@ -114,3 +114,8 @@ export type HogeFugaType = z.infer<typeof hogeFugaSchema>;
   }
 }
 ```
+
+## rulesync
+
+複数のAI開発ツール間でコーディング規約を統一管理するため、rulesyncを試験的に導入しています。
+`.rulesync/`ディレクトリに統一ルールを配置し、各ツール向けの設定ファイルは自動生成します。


### PR DESCRIPTION
## 内容

`docs/細かい設計方針.md` にrulesyncについての説明を追加しました。

- rulesyncの導入目的（複数のAI開発ツール間でコーディング規約を統一管理）
- 運用方針（試験的導入、`.rulesync/`ディレクトリに統一ルールを配置）

## 関連 PR

- VOICEVOX/voicevox#2918